### PR TITLE
Alpha Blend Text

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -69,6 +69,7 @@ impl Draw {
 
         let pipe = Arc::new(
             GraphicsPipeline::start()
+                .blend_alpha_blending()
                 .vertex_input(SingleInstanceBufferDefinition::<Vertex>::new())
                 .vertex_shader(vs.main_entry_point(), ())
                 .triangle_strip()


### PR DESCRIPTION
The default behavior in Vulkan is to use blend_pass_through, which "Each fragment shader output will have its value directly written to the framebuffer attachment. This is the default."

Default behavior leaves jaggies although the font texture appropriately has none.

Sub-pixel support in rusttype is no known or addressed in this commit, but fiddling with the provided shader showed only the R channel to be non-zero.

The documents for vulkano also include `blend_collective` and this was also effective at achieving proper alpha blending into the background.  If you are reading git blame and suspect that the alpha compositing is not meeting your needs, investigate the other pipeline blending methods for vulkano::pipeline::PipelineBuilder

Before:
![jaggy](https://user-images.githubusercontent.com/641139/53918008-3c7d3500-40a9-11e9-81cc-8b0a76d40869.png)

After:
![smooth](https://user-images.githubusercontent.com/641139/53918011-3f782580-40a9-11e9-88ea-cf662c34f9f9.png)

